### PR TITLE
Update composer.json - Correct licence identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "mattkeys/acf-conditional-taxonomy-rules",
   "type": "wordpress-plugin",
   "description": "This plugin expands on the ACF conditional functionality to allow for conditionals based on a selected taxonomy term ID.",
-  "license": "GPLv2 or later",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Matt Keys",


### PR DESCRIPTION
Should fix the following Packagist error - License "GPLv2 or later" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.